### PR TITLE
dts: zynq zx common: fix dtc warnings

### DIFF
--- a/arch/arm/boot/dts/zynq-enclustra-zx-common.dtsi
+++ b/arch/arm/boot/dts/zynq-enclustra-zx-common.dtsi
@@ -1,21 +1,21 @@
 / {
-	memory {
+	memory@20000000 {
 		device_type = "memory";
 		reg = <0x0 0x20000000>;
 	};
 
 	chosen {
-		linux,stdout-path = "/amba/serial@e0000000";
+		stdout-path = "/amba/serial@e0000000";
 	};
 
-	usb_phy0: phy0 {
+	usb_phy0: phy0@e0002000 {
 		compatible = "ulpi-phy";
 		#phy-cells = <0>;
 		reg = <0xe0002000 0x1000>;
 		view-port = <0x0170>;
 		drv-vbus;
 	};
-	mdio {
+	mdio@e000b000 {
                 compatible = "cdns,macb-mdio";
                 reg = <0xe000b000 0x1000>;
                 clocks = <&clkc 30>, <&clkc 30>, <&clkc 13>;

--- a/arch/arm/boot/dts/zynq-enclustra-zx-common.dtsi
+++ b/arch/arm/boot/dts/zynq-enclustra-zx-common.dtsi
@@ -15,18 +15,18 @@
 		view-port = <0x0170>;
 		drv-vbus;
 	};
-	mdio@e000b000 {
-                compatible = "cdns,macb-mdio";
-                reg = <0xe000b000 0x1000>;
-                clocks = <&clkc 30>, <&clkc 30>, <&clkc 13>;
-                clock-names = "pclk", "hclk", "tx_clk";
-                #address-cells = <1>;
-                #size-cells = <0>;
-                phy3: ethernet-phy@3 {
-                        reg = <3>;
-                };
-        };
 
+	mdio@e000b000 {
+		compatible = "cdns,macb-mdio";
+		reg = <0xe000b000 0x1000>;
+		clocks = <&clkc 30>, <&clkc 30>, <&clkc 13>;
+		clock-names = "pclk", "hclk", "tx_clk";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		phy3: ethernet-phy@3 {
+		        reg = <3>;
+		};
+	};
 };
 
 &gem0 {

--- a/arch/arm/boot/dts/zynq-enclustra-zx-common.dtsi
+++ b/arch/arm/boot/dts/zynq-enclustra-zx-common.dtsi
@@ -1,5 +1,5 @@
 / {
-	memory@20000000 {
+	memory@0 {
 		device_type = "memory";
 		reg = <0x0 0x20000000>;
 	};


### PR DESCRIPTION
The following warnings are issued before this fix:

```
devicetree_test.dtb: Warning (unit_address_vs_reg): /memory: node has a reg or ranges property, but no unit name
devicetree_test.dtb: Warning (unit_address_vs_reg): /phy0: node has a reg or ranges property, but no unit name
devicetree_test.dtb: Warning (unit_address_vs_reg): /mdio: node has a reg or ranges property, but no unit name
devicetree_test.dtb: Warning (chosen_node_stdout_path): /chosen:linux,stdout-path: Use 'stdout-path' instead
```
This PR resolves those.
